### PR TITLE
Move iframe ID assignment out of the template.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ android: cordova-init cordova-www
 
 go-test: npm-install bindata
 	rm -rf ${GOPATH}/pkg/*_js
-	gopherjs test --tags=debug,safe github.com/FlashbackSRS/flashback/util github.com/FlashbackSRS/flashback/repository/test github.com/FlashbackSRS/flashback/repository
+	gopherjs test --tags=debug,safe github.com/FlashbackSRS/flashback/util github.com/FlashbackSRS/flashback/repository/test github.com/FlashbackSRS/flashback/repository github.com/FlashbackSRS/flashback/webclient/handlers/study
 
 test: go-test
 

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,13 @@ cordova-init: plugins platforms
 android: cordova-init cordova-www
 	cordova run android
 
-go-test: npm-install bindata
-	rm -rf ${GOPATH}/pkg/*_js
-	gopherjs test --tags=debug,safe github.com/FlashbackSRS/flashback/util github.com/FlashbackSRS/flashback/repository/test github.com/FlashbackSRS/flashback/repository github.com/FlashbackSRS/flashback/webclient/handlers/study
+go-test: preclean npm-install bindata
+	gopherjs test `go list ./...`
 
 test: go-test
+
+preclean:
+	rm -rf ${GOPATH}/pkg/*_js
 
 clean:
 	rm -rf www bundle.js pre-bundle.js bundle.js.map flashback main.js main.js.map
@@ -67,8 +69,7 @@ www/js/cardframe.js: webclient/js/cardframe.js
 	cp $< $@
 
 .PHONY: main.js
-main.js: bindata
-	rm -rf ${GOPATH}/pkg/*_js
+main.js: preclean bindata
 	gopherjs build --tags=debug ./webclient/*.go
 # 	uglifyjs main.js -c -m -o $@
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package flashback
 
 import (

--- a/repository/done/done.go
+++ b/repository/done/done.go
@@ -38,10 +38,7 @@ func (c *Card) Action(_ *int, _ time.Time, _ studyview.Button) (done bool, err e
 }
 
 // Body returns the Done card body.
-func (c *Card) Body(_ int) (string, string, error) {
+func (c *Card) Body(_ int) (string, error) {
 	body, err := Asset("done.html")
-	if err != nil {
-		return "", "", err
-	}
-	return string(body), "doneIFrame", nil
+	return string(body), err
 }

--- a/repository/test/card_test.go
+++ b/repository/test/card_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 var revRE = regexp.MustCompile(`"_rev":"\d-[0-9a-f]+?"`)
-var iframeRE = regexp.MustCompile(`iframeID: '[0-9a-f]+?'`)
 
 func init() {
 	mock.RegisterMock("anki-basic")
@@ -28,16 +27,14 @@ func TestCard1(t *testing.T) {
 	require.Nil(err, "Error fetching card: %s", err)
 	require.NotNil(card, "Card is nil")
 
-	question, _, err := card.Body(repo.Question)
+	question, err := card.Body(repo.Question)
 	require.Nil(err, "Unable to fetch the card's question body: %s", err)
 	question = revRE.ReplaceAllString(question, `"_rev":"X-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"`)
-	question = iframeRE.ReplaceAllString(question, `iframeID: 'xxxxxxxxxxxxxxxx'`)
 	require.LinesEqual(expectedQuestion0, question, "Card 0 question")
 
-	answer, _, err := card.Body(repo.Answer)
+	answer, err := card.Body(repo.Answer)
 	require.Nil(err, "Unable to fetch the card's answer body: %s", err)
 	answer = revRE.ReplaceAllString(answer, `"_rev":"X-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"`)
-	answer = iframeRE.ReplaceAllString(answer, `iframeID: 'xxxxxxxxxxxxxxxx'`)
 	require.LinesEqual(expectedAnswer0, answer, "Card 0 answer")
 }
 
@@ -52,16 +49,14 @@ func TestCard2(t *testing.T) {
 	require.Nil(err, "Error fetching card: %s", err)
 	require.NotNil(card, "Card is nil")
 
-	question, _, err := card.Body(repo.Question)
+	question, err := card.Body(repo.Question)
 	require.Nil(err, "Unable to fetch the card's body: %s", err)
 	question = revRE.ReplaceAllString(question, `"_rev":"X-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"`)
-	question = iframeRE.ReplaceAllString(question, `iframeID: 'xxxxxxxxxxxxxxxx'`)
 	require.LinesEqual(expectedQuestion1, question, "Card 1 question")
 
-	answer, _, err := card.Body(repo.Answer)
+	answer, err := card.Body(repo.Answer)
 	require.Nil(err, "Unable to fetch the card's answer body: %s", err)
 	answer = revRE.ReplaceAllString(answer, `"_rev":"X-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"`)
-	answer = iframeRE.ReplaceAllString(answer, `iframeID: 'xxxxxxxxxxxxxxxx'`)
 	require.LinesEqual(expectedAnswer1, answer, "Card 1 answer")
 }
 
@@ -73,7 +68,6 @@ var expectedQuestion0 = `<!DOCTYPE html><html><head>
 <script type="text/javascript">
 'use strict';
 var FB = {
-	iframeID: 'xxxxxxxxxxxxxxxx',
 	card: {"id":"card-alnlcvykyjxsjtijzonc3456kd5u4757.ZR4TpeX38xRzRvXprlgJpP4Ribo.0"},
 	note: {"id":"note-ZR4TpeX38xRzRvXprlgJpP4Ribo"}
 };
@@ -97,7 +91,6 @@ var expectedAnswer0 = `<!DOCTYPE html><html><head>
 <script type="text/javascript">
 'use strict';
 var FB = {
-	iframeID: 'xxxxxxxxxxxxxxxx',
 	card: {"id":"card-alnlcvykyjxsjtijzonc3456kd5u4757.ZR4TpeX38xRzRvXprlgJpP4Ribo.0"},
 	note: {"id":"note-ZR4TpeX38xRzRvXprlgJpP4Ribo"}
 };
@@ -125,7 +118,6 @@ var expectedQuestion1 = `<!DOCTYPE html><html><head>
 <script type="text/javascript">
 'use strict';
 var FB = {
-	iframeID: 'xxxxxxxxxxxxxxxx',
 	card: {"id":"card-alnlcvykyjxsjtijzonc3456kd5u4757.ZR4TpeX38xRzRvXprlgJpP4Ribo.1"},
 	note: {"id":"note-ZR4TpeX38xRzRvXprlgJpP4Ribo"}
 };
@@ -149,7 +141,6 @@ var expectedAnswer1 = `<!DOCTYPE html><html><head>
 <script type="text/javascript">
 'use strict';
 var FB = {
-	iframeID: 'xxxxxxxxxxxxxxxx',
 	card: {"id":"card-alnlcvykyjxsjtijzonc3456kd5u4757.ZR4TpeX38xRzRvXprlgJpP4Ribo.1"},
 	note: {"id":"note-ZR4TpeX38xRzRvXprlgJpP4Ribo"}
 };

--- a/repository/theme.go
+++ b/repository/theme.go
@@ -87,7 +87,6 @@ var masterTemplate = `
 <script type="text/javascript">
 'use strict';
 var FB = {
-	iframeID: '{{ .IframeID }}',
 	card: {{ .Card }},
 	note: {{ .Note }}
 };

--- a/webclient/handlers/study/study_test.go
+++ b/webclient/handlers/study/study_test.go
@@ -1,0 +1,30 @@
+package studyhandler
+
+import "testing"
+
+type iframeTest struct {
+	Input    string
+	Expected string
+}
+
+func TestAddIframeID(t *testing.T) {
+	tests := []iframeTest{
+		iframeTest{
+			Input:    `<html><head></head><body><h1>Foo!</h1></body></html>`,
+			Expected: `<html><head><meta name="iframeid" content="__IFRAME__"/></head><body><h1>Foo!</h1></body></html>`,
+		},
+		iframeTest{
+			Input:    `Don't look now!`,
+			Expected: `<html><head><meta name="iframeid" content="__IFRAME__"/></head><body>Don&#39;t look now!</body></html>`,
+		},
+	}
+	for _, test := range tests {
+		result, err := addIframeID(test.Input, "__IFRAME__")
+		if err != nil {
+			t.Errorf("Unexpected error: %s\n", err)
+		}
+		if result != test.Expected {
+			t.Errorf("Iframe not injected as expected\n\tExpected: %s\n\t  Actual: %s\n", test.Expected, result)
+		}
+	}
+}

--- a/webclient/js/cardframe.js
+++ b/webclient/js/cardframe.js
@@ -1,6 +1,17 @@
 'use strict';
 var requests = {};
+var iframeID;
 window.addEventListener('error', function(e) {
+    if (typeof(iframeID) === 'undefined') {
+        var metas = document.GetElementsByTagName('meta');
+        for (var i=0; i < metas.length; i++) {
+            if (metas[i].getAttribute("name") == "iframeid") {
+                iframeID = metas[i].getAttribute("content");
+                break;
+            }
+        }
+        console.log("Didn't find the iframe ID!!")
+    }
     var t = e.target;
     var tag = t.tagName;
     var path = tag == 'LINK' ? t.getAttribute('href') : t.getAttribute('src');
@@ -12,7 +23,7 @@ window.addEventListener('error', function(e) {
             targets: []
         };
         parent.postMessage({
-            IframeID: FB.iframeID,
+            IframeID: iframeID,
             Tag: tag,
             CardID: FB.card.id,
             Path: path,


### PR DESCRIPTION
This simplifies templates significantly, so that they don't have to worry about
these internal details. The potential drawback is that it means parsing the HTML
an additional time, which is less efficient.