### PR TITLE
Don't panic if we can't play audio for mobile Chrome

### DIFF
--- a/webclient/js/cardframe.js
+++ b/webclient/js/cardframe.js
@@ -184,11 +184,19 @@
     function playWhenReady(media) {
         // A lazy way to check if the media file has been loaded yet.
         if ( media.src.match(/^blob:/) ) {
-            media.play();
+            try {
+                media.play();
+            } catch (e) {
+                console.log(e);
+            }
             return;
         }
         media.addEventListener('canplay', function() {
-            media.play();
+            try {
+                media.play();
+            } catch (e) {
+                console.log(e);
+            }
         });
     }
 


### PR DESCRIPTION
Playing audio requires pressing the play button for now. Hopefully in Phonegap it will be easy to auto-play (it is, if memory serves).